### PR TITLE
docs: fix docker compose link in toc

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 - [技术栈](#技术栈)
 - [部署](#部署)
-- [Docker Compose 最佳实践](#Docker Compose 最佳实践)
+- [Docker Compose 最佳实践](#Docker-Compose-最佳实践)
 - [环境变量](#环境变量)
 - [配置说明](#配置说明)
 - [管理员配置](#管理员配置)


### PR DESCRIPTION
Hi there, I noticed a minor typo in the table of contents and wanted to quickly fix 😃

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/a6183d4f-832a-4fc3-96af-6a4ecdc052f9) | ![After](https://github.com/user-attachments/assets/0d813de8-39d0-4247-9036-30007ca1f63f) |
