### PR TITLE
fix: ensure GHCR image tags use lowercase repository owner

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,6 +26,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set lowercase repository owner
+        id: lowercase
+        run: echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -34,8 +38,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ github.repository_owner }}/moontv:latest
-            ghcr.io/${{ github.repository_owner }}/moontv:${{ github.sha }} 
+            ghcr.io/${{ steps.lowercase.outputs.owner }}/moontv:latest
+            ghcr.io/${{ steps.lowercase.outputs.owner }}/moontv:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
GitHub 用户名（repository_owner）包含大写字母时，会导致构建并推送镜像到 GitHub Container Registry 时触发错误："repository name must be lowercase"。

> buildx failed with: ERROR: failed to build: invalid tag "ghcr.io/RiverOnVenus/moontv:latest": repository name must be lowercase

见：https://github.com/RiverOnVenus/MoonTV/actions/runs/16348923603

action 新增一个步骤，将 github.repository_owner 转换为小写，在 docker build-push-action 的 tags 字段中，替换原有的 repository_owner 为小写版本。无报错，见：https://github.com/RiverOnVenus/MoonTV/actions/runs/16349951006